### PR TITLE
feat: gamified UI and quest scoring

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,12 +3,19 @@ import Header from './components/Header';
 import BudgetBoard from './components/BudgetBoard';
 import ChartPanel from './components/ChartPanel';
 import ImpactTooltip from './components/ImpactTooltip.jsx';
+import QuestPanel from './components/QuestPanel';
+import ScoreBar from './components/ScoreBar';
+import { useBudgetStore } from './hooks/useBudgetStore';
 
 export default function App() {
+  const activeQuestId = useBudgetStore((s) => s.activeQuestId);
+
   return (
     <div className="min-h-screen bg-gray-100">
       <Header title="Pocket Participatory Budget" />
       <main className="max-w-6xl mx-auto p-4 space-y-6">
+        <QuestPanel />
+        {activeQuestId && <ScoreBar />}
         <ChartPanel />
         <ImpactTooltip />
         <BudgetBoard />

--- a/src/components/BudgetBoard.jsx
+++ b/src/components/BudgetBoard.jsx
@@ -6,11 +6,30 @@ export default function BudgetBoard() {
   // 1) Get the list of sectors from our store
   const sectors = useBudgetStore((state) => state.sectors);
 
+  // Group sectors into rows of 3 for gradient zones
+  const rows = [];
+  for (let i = 0; i < sectors.length; i += 3) {
+    rows.push(sectors.slice(i, i + 3));
+  }
+  const gradients = [
+    'from-blue-50 to-blue-100',
+    'from-green-50 to-green-100',
+    'from-orange-50 to-orange-100'
+  ];
+
   return (
-    // 2) Render a responsive grid of SectorCard components
-    <div className="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {sectors.map((sec) => (
-        <SectorCard key={sec.name} sector={sec} />
+    <div className="space-y-4 p-4">
+      {rows.map((row, idx) => (
+        <div
+          key={idx}
+          className={`p-4 rounded-lg bg-gradient-to-r ${gradients[idx % gradients.length]}`}
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {row.map((sec) => (
+              <SectorCard key={sec.name} sector={sec} />
+            ))}
+          </div>
+        </div>
       ))}
     </div>
   );

--- a/src/components/ChartPanel.jsx
+++ b/src/components/ChartPanel.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useBudgetStore } from '../hooks/useBudgetStore';
 // Chart.js and react-chartjs-2
 import { Doughnut } from 'react-chartjs-2';
@@ -17,6 +17,14 @@ export default function ChartPanel() {
   const totalOriginal = useBudgetStore((state) => state.getTotalOriginal());
   const totalCurrent = useBudgetStore((state) => state.getTotalCurrent());
 
+  // Trigger a subtle scale animation when current total updates
+  const [animate, setAnimate] = useState(false);
+  useEffect(() => {
+    setAnimate(true);
+    const t = setTimeout(() => setAnimate(false), 300);
+    return () => clearTimeout(t);
+  }, [totalCurrent]);
+
   // Prepare data for the chart
   const data = {
     labels: ['Original', 'Current'],
@@ -30,10 +38,16 @@ export default function ChartPanel() {
   };
 
   return (
-    <div className="p-4 bg-white rounded-lg shadow">
+    <div className="p-4 bg-white rounded-lg shadow flex flex-col items-center">
       <h2 className="text-xl font-semibold mb-2">Budget Allocation Comparison</h2>
-      <Doughnut data={data} />
-      <div className="mt-4 text-sm flex justify-around">
+      <div
+        className={`w-64 h-64 flex items-center justify-center transition-transform duration-300 ${
+          animate ? 'scale-105' : 'scale-100'
+        }`}
+      >
+        <Doughnut data={data} />
+      </div>
+      <div className="mt-4 text-sm flex justify-around w-full">
         <div className="flex items-center">
           <span className="inline-block w-3 h-3 bg-[#0069B4] mr-1"></span>Original
         </div>

--- a/src/components/ImpactTooltip.jsx
+++ b/src/components/ImpactTooltip.jsx
@@ -17,7 +17,6 @@ export default function ImpactTooltip() {
     if (Math.abs(deltaPct) < 1) return [];// skip tiny changes
 
     const effect = (rule.coeff * deltaPct).toFixed(1);
-    const direction = deltaPct > 0 ? 'increase' : 'decrease';
     const verb = deltaPct > 0 ? 'Increasing' : 'Decreasing';
 
     return [`${verb} ${name} by ${Math.abs(deltaPct.toFixed(1))}% will ${rule.description} by ${Math.abs(effect)} ${rule.unit}.`];

--- a/src/components/QuestPanel.jsx
+++ b/src/components/QuestPanel.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useBudgetStore } from '../hooks/useBudgetStore';
+
+export default function QuestPanel() {
+  const { quests, activeQuestId, setQuest, clearQuest } = useBudgetStore();
+
+  const handleSelect = (id) => {
+    if (activeQuestId === id) {
+      clearQuest();
+    } else {
+      setQuest(id);
+    }
+  };
+
+  return (
+    <section className="bg-gradient-to-r from-blue-700 to-indigo-500 text-white p-4 rounded-lg shadow">
+      <h2 className="text-lg font-bold mb-2">Quest Mode</h2>
+      <div className="flex flex-wrap gap-4">
+        {quests.map((q) => (
+          <button
+            key={q.id}
+            onClick={() => handleSelect(q.id)}
+            className={`p-3 rounded-md text-left w-60 transition transform hover:scale-105 focus:outline-none ${
+              activeQuestId === q.id ? 'bg-orange-500' : 'bg-blue-600'
+            }`}
+          >
+            <div className="font-semibold">{q.name}</div>
+            <p className="text-sm mt-1">{q.description}</p>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ScoreBar.jsx
+++ b/src/components/ScoreBar.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useBudgetStore } from '../hooks/useBudgetStore';
+
+export default function ScoreBar() {
+  const { getQuestScore } = useBudgetStore();
+  const { score, success } = getQuestScore();
+  const barColor = success ? 'bg-green-500' : 'bg-red-500';
+
+  return (
+    <div className="w-full bg-gray-200 rounded-full h-4 overflow-hidden shadow-inner">
+      <div
+        className={`${barColor} h-4 transition-[width] duration-500`}
+        style={{ width: `${score}%` }}
+      />
+      <p className="mt-1 text-sm font-semibold text-center">Score: {score}</p>
+    </div>
+  );
+}

--- a/src/components/SectorCard.jsx
+++ b/src/components/SectorCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useBudgetStore } from '../hooks/useBudgetStore';
+import impactRules from '../data/impact_rules.json';
 
 // Helper to format numbers as Rs 1,234,567
 const fmt = (n) =>
@@ -16,8 +17,20 @@ export default function SectorCard({ sector }) {
   // Determine color for current vs original
   const deltaColor = value >= original ? 'text-green-600' : 'text-red-600';
 
+  // Impact calculation
+  const rule = impactRules.find((r) => r.sector === name);
+  const deltaPct = ((value - original) / original) * 100;
+  const showImpact = rule && Math.abs(deltaPct) >= 5;
+  let impactText = '';
+  if (rule) {
+    const effect = rule.coeff * deltaPct;
+    const action = deltaPct < 0 ? 'Cutting' : 'Boosting';
+    const sign = effect > 0 ? '+' : '';
+    impactText = `${action} ${rule.short || name} by ${Math.abs(deltaPct).toFixed(1)}% → ${rule.description} ${sign}${effect.toFixed(1)}${rule.unit}`;
+  }
+
   return (
-    <div className="p-6 bg-gray-50 border border-gray-200 rounded-lg shadow-sm">
+    <div className="p-6 bg-white border-2 border-blue-800 rounded-xl shadow-md transition-transform transform hover:-translate-y-1 hover:shadow-xl">
       <h3 className="text-lg font-semibold mb-2">{name}</h3>
 
       {/* Slider */}
@@ -27,7 +40,7 @@ export default function SectorCard({ sector }) {
         max={original * 2}
         value={value}
         onChange={handleChange}
-        className="w-full h-2 mb-4 accent-govBlue"
+        className="w-full h-2 mb-4 accent-orange-500 transition-transform duration-300 active:scale-105"
         aria-label={`Adjust budget for ${name}`}
       />
 
@@ -42,6 +55,17 @@ export default function SectorCard({ sector }) {
           <span className={deltaColor}>{fmt(value)}</span>
         </div>
       </div>
+
+      {/* Impact line */}
+      {rule && (
+        <p
+          className={`mt-2 text-sm transition-opacity duration-300 ${
+            showImpact ? 'opacity-100' : 'opacity-0'
+          } ${deltaPct < 0 ? 'text-orange-600' : 'text-green-600'}`}
+        >
+          {impactText}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/data/impact_rules.json
+++ b/src/data/impact_rules.json
@@ -1,20 +1,12 @@
 [
-  {
-    "sector": "CABINET SECRETARIAT",
-    "coeff": 0.02,
-    "description": "administrative efficiency loss",
-    "unit": "percentage points"
-  },
-  {
-    "sector": "AVIATION MINISTRY",
-    "coeff": 0.05,
-    "description": "flight delay minutes",
-    "unit": "minutes"
-  },
-  {
-    "sector": "EDUCATION MINISTRY",
-    "coeff": 0.1,
-    "description": "student dropout rate increase",
-    "unit": "percentage points"
-  }
+  { "sector": "FINANCE AND REVENUE MINISTRY", "short": "Finance", "coeff": 0.5, "description": "tax refunds", "unit": " days" },
+  { "sector": "ECONOMIC AFFAIRS MINISTRY", "short": "Economic Affairs", "coeff": 0.1, "description": "project delays", "unit": " months" },
+  { "sector": "DEFENCE MINISTRY", "short": "Defence", "coeff": -0.3, "description": "readiness", "unit": "%" },
+  { "sector": "POVERTY ALLEVIATION AND SOCIAL SAFETY MINISTRY", "short": "Social Safety", "coeff": -1000, "description": "families helped", "unit": "" },
+  { "sector": "ENERGY MINISTRY", "short": "Energy", "coeff": 0.2, "description": "outage hours", "unit": " h" },
+  { "sector": "INTERIOR AND NARCOTICS CONTROL MINISTRY", "short": "Interior", "coeff": 0.3, "description": "response time", "unit": " min" },
+  { "sector": "CABINET SECRETARIAT", "short": "Cabinet", "coeff": -0.1, "description": "gov efficiency", "unit": "%" },
+  { "sector": "FOREIGN AFFAIRS MINISTRY", "short": "Foreign Affairs", "coeff": -1, "description": "diplomatic missions", "unit": "" },
+  { "sector": "FEDERAL EDUCATION PROFESSIONAL TRAINING Pages NATIONAL HERITAGE AND CULTURE MINISTRY", "short": "Education", "coeff": -0.5, "description": "student outcomes", "unit": "%" },
+  { "sector": "RAILWAYS MINISTRY", "short": "Railways", "coeff": 0.4, "description": "train delays", "unit": " min" }
 ]

--- a/src/hooks/useBudgetStore.js
+++ b/src/hooks/useBudgetStore.js
@@ -12,6 +12,21 @@ const initialSectors = budgetData.map((s) => ({
 export const useBudgetStore = create((set, get) => ({
   sectors: initialSectors,
 
+  // Quest definitions
+  quests: [
+    {
+      id: 'boost-education',
+      name: 'Boost Education',
+      description:
+        'Increase Education budget by ≥15% while keeping Health ≥80%',
+      target: { sector: 'EDUCATION MINISTRY', pct: 15 },
+      constraints: [
+        { sector: 'HEALTH MINISTRY', minPct: 80 },
+      ],
+    },
+  ],
+  activeQuestId: null,
+
   // Update a sector's current value
   setSectorValue: (name, newValue) => set((state) => ({
     sectors: state.sectors.map((sec) =>
@@ -27,4 +42,41 @@ export const useBudgetStore = create((set, get) => ({
 
   // Get total of current allocations
   getTotalCurrent: () => get().sectors.reduce((sum, s) => sum + s.value, 0),
+
+  // Quest actions
+  setQuest: (id) => set({ activeQuestId: id }),
+  clearQuest: () => set({ activeQuestId: null }),
+
+  // Compute quest score
+  getQuestScore: () => {
+    const { activeQuestId, quests, sectors } = get();
+    const quest = quests.find((q) => q.id === activeQuestId);
+    if (!quest) return { score: 0, success: false };
+
+    const targetSec = sectors.find((s) => s.name === quest.target.sector);
+    const increasePct =
+      ((targetSec.value - targetSec.original) / targetSec.original) * 100;
+    let score = Math.min(
+      60,
+      Math.max(0, (increasePct / quest.target.pct) * 60)
+    );
+
+    let constraintsMet = true;
+    quest.constraints.forEach((c) => {
+      const sec = sectors.find((s) => s.name === c.sector);
+      const pct = (sec.value / sec.original) * 100;
+      const share = 40 / quest.constraints.length;
+      if (pct >= c.minPct) {
+        score += share;
+      } else {
+        score -= share;
+        constraintsMet = false;
+      }
+    });
+
+    score = Math.max(0, Math.min(100, Math.round(score)));
+    const success =
+      increasePct >= quest.target.pct && constraintsMet;
+    return { score, success };
+  },
 }));


### PR DESCRIPTION
## Summary
- add quest definitions, active selection, and score calculation to budget store
- introduce QuestPanel and ScoreBar components and integrate them into the app

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_e_689284308b88832c9e8826c94bd4d733