### PR TITLE
Add badge system with trophy case

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,9 +9,11 @@ import BadgeModal from './components/BadgeModal';
 import { useBudgetStore } from './hooks/useBudgetStore';
 
 export default function App() {
-  const activeQuestId = useBudgetStore((s) => s.activeQuestId);
-  const recentBadge = useBudgetStore((s) => s.recentBadge);
-  const clearRecentBadge = useBudgetStore((s) => s.clearRecentBadge);
+  const { activeQuestId, recentBadge, clearRecentBadge } = useBudgetStore((s) => ({
+    activeQuestId: s.activeQuestId,
+    recentBadge: s.recentBadge,
+    clearRecentBadge: s.clearRecentBadge,
+  }));
   const [showBadges, setShowBadges] = React.useState(false);
 
   React.useEffect(() => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,14 +5,30 @@ import ChartPanel from './components/ChartPanel';
 import ImpactTooltip from './components/ImpactTooltip.jsx';
 import QuestPanel from './components/QuestPanel';
 import ScoreBar from './components/ScoreBar';
+import BadgeModal from './components/BadgeModal';
 import { useBudgetStore } from './hooks/useBudgetStore';
 
 export default function App() {
   const activeQuestId = useBudgetStore((s) => s.activeQuestId);
+  const recentBadge = useBudgetStore((s) => s.recentBadge);
+  const clearRecentBadge = useBudgetStore((s) => s.clearRecentBadge);
+  const [showBadges, setShowBadges] = React.useState(false);
+
+  React.useEffect(() => {
+    if (recentBadge) {
+      const t = setTimeout(() => clearRecentBadge(), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [recentBadge, clearRecentBadge]);
 
   return (
     <div className="min-h-screen bg-gray-100">
-      <Header title="Pocket Participatory Budget" />
+      <Header title="Pocket Participatory Budget" onShowBadges={() => setShowBadges(true)} />
+      {recentBadge && (
+        <div className="fixed top-4 right-4 bg-yellow-300 text-black px-4 py-2 rounded shadow-lg animate-bounce">
+          Badge Unlocked: {recentBadge.name}
+        </div>
+      )}
       <main className="max-w-6xl mx-auto p-4 space-y-6">
         <QuestPanel />
         {activeQuestId && <ScoreBar />}
@@ -20,6 +36,7 @@ export default function App() {
         <ImpactTooltip />
         <BudgetBoard />
       </main>
+      {showBadges && <BadgeModal onClose={() => setShowBadges(false)} />}
     </div>
   );
 }

--- a/src/components/BadgeModal.jsx
+++ b/src/components/BadgeModal.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { useBudgetStore } from '../hooks/useBudgetStore';
 
 export default function BadgeModal({ onClose }) {
-  const badges = useBudgetStore((s) => s.badges);
-  const earnedBadges = useBudgetStore((s) => s.earnedBadges);
+  const { badges, earnedBadges } = useBudgetStore((s) => ({
+    badges: s.badges,
+    earnedBadges: s.earnedBadges,
+  }));
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">

--- a/src/components/BadgeModal.jsx
+++ b/src/components/BadgeModal.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useBudgetStore } from '../hooks/useBudgetStore';
+
+export default function BadgeModal({ onClose }) {
+  const badges = useBudgetStore((s) => s.badges);
+  const earnedBadges = useBudgetStore((s) => s.earnedBadges);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded-lg shadow-lg max-w-md w-full">
+        <h2 className="text-xl font-bold mb-4">Trophy Case</h2>
+        <ul className="space-y-3">
+          {badges.map((b) => {
+            const unlocked = earnedBadges.includes(b.id);
+            return (
+              <li
+                key={b.id}
+                className={`p-3 border rounded-md ${unlocked ? 'bg-yellow-100' : 'bg-gray-100 text-gray-400'}`}
+              >
+                <div className="font-semibold">{b.name}</div>
+                <p className="text-sm">{b.description}</p>
+              </li>
+            );
+          })}
+        </ul>
+        <button
+          onClick={onClose}
+          className="mt-6 px-4 py-2 bg-blue-600 text-white rounded-md"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,10 +1,18 @@
 import React from 'react';
 
-export default function Header({ title }) {
+export default function Header({ title, onShowBadges }) {
   return (
     <header className="bg-white shadow">
-      <div className="max-w-6xl mx-auto p-4">
+      <div className="max-w-6xl mx-auto p-4 flex justify-between items-center">
         <h1 className="text-2xl font-bold">{title}</h1>
+        {onShowBadges && (
+          <button
+            onClick={onShowBadges}
+            className="px-3 py-1 bg-yellow-400 rounded-md shadow"
+          >
+            Trophy Case
+          </button>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- track badge milestones like Balanced Budget and Health Champion in Zustand store
- show animated toast when unlocking a badge
- add Trophy Case modal to review collected badges

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68928e0b1920832caa5615e8af41d51f