### PR TITLE
feat: add smart consequence tooltip

### DIFF
--- a/src/components/ImpactTooltip.jsx
+++ b/src/components/ImpactTooltip.jsx
@@ -1,37 +1,51 @@
-
 import React from 'react';
 import rulesList from '../data/impact_rules.json';
 import { useBudgetStore } from '../hooks/useBudgetStore';
+import { t } from '../i18n';
 
 export default function ImpactTooltip() {
-  // 1) Get current sectors state
-  const sectors = useBudgetStore((state) => state.sectors);
+  // Pull state
+  const { sectors, lang } = useBudgetStore((state) => ({
+    sectors: state.sectors,
+    lang: state.lang || 'en',
+  }));
 
-  // 2) Generate messages based on percentage changes
+  // Build consequence messages
   const messages = sectors.flatMap((sec) => {
     const { name, original, value } = sec;
     const rule = rulesList.find((r) => r.sector === name);
     if (!rule) return [];
 
     const deltaPct = ((value - original) / original) * 100;
-    if (Math.abs(deltaPct) < 1) return [];// skip tiny changes
+    if (Math.abs(deltaPct) < 5) return []; // ignore small tweaks
 
-    const effect = (rule.coeff * deltaPct).toFixed(1);
-    const verb = deltaPct > 0 ? 'Increasing' : 'Decreasing';
+    const effect = rule.coeff * deltaPct;
+    const verb = deltaPct > 0 ? t('increasing', lang) : t('decreasing', lang);
+    const impactVerb = effect >= 0 ? t('increase', lang) : t('decrease', lang);
+    const icon = effect >= 0 ? '✅' : Math.abs(deltaPct) > 15 ? '❗' : '⚠️';
 
-    return [`${verb} ${name} by ${Math.abs(deltaPct.toFixed(1))}% will ${rule.description} by ${Math.abs(effect)} ${rule.unit}.`];
+    const msg = `${verb} ${rule.short || name} ${t('by', lang)} ${Math.abs(deltaPct).toFixed(1)}% ${t('will', lang)} ${impactVerb} ${rule.description} ${t('by', lang)} ${Math.abs(effect).toFixed(1)}${rule.unit}.`;
+    return [{ icon, text: msg }];
   });
 
   if (messages.length === 0) return null;
 
   return (
     <div className="p-4 bg-white rounded-lg shadow max-h-60 overflow-y-auto">
-      <h2 className="text-lg font-semibold mb-2">Impact Insights</h2>
+      <h2 className="text-lg font-semibold mb-2">{t('impactInsights', lang)}</h2>
       <ul className="list-disc list-inside text-sm space-y-1">
-        {messages.map((msg, i) => (
-          <li key={i}>{msg}</li>
+        {messages.map((m, i) => (
+          <li
+            key={i}
+            className="flex items-start gap-2"
+            style={{ animation: 'fadeIn 0.3s ease' }}
+          >
+            <span>{m.icon}</span>
+            <span>{m.text}</span>
+          </li>
         ))}
       </ul>
+      <style>{`@keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }`}</style>
     </div>
   );
 }

--- a/src/data/impact_rules.json
+++ b/src/data/impact_rules.json
@@ -8,5 +8,6 @@
   { "sector": "CABINET SECRETARIAT", "short": "Cabinet", "coeff": 0.1, "description": "gov efficiency", "unit": "%" },
   { "sector": "FOREIGN AFFAIRS MINISTRY", "short": "Foreign Affairs", "coeff": 1, "description": "diplomatic missions", "unit": "" },
   { "sector": "FEDERAL EDUCATION PROFESSIONAL TRAINING Pages NATIONAL HERITAGE AND CULTURE MINISTRY", "short": "Education", "coeff": 0.5, "description": "student outcomes", "unit": "%" },
-  { "sector": "RAILWAYS MINISTRY", "short": "Railways", "coeff": -0.4, "description": "train delays", "unit": " min" }
+  { "sector": "RAILWAYS MINISTRY", "short": "Railways", "coeff": -0.4, "description": "train delays", "unit": " min" },
+  { "sector": "HEALTH MINISTRY", "short": "Health", "coeff": -0.25, "description": "life expectancy", "unit": " years" }
 ]

--- a/src/hooks/useBudgetStore.js
+++ b/src/hooks/useBudgetStore.js
@@ -11,6 +11,8 @@ const initialSectors = budgetData.map((s) => ({
 // Zustand store
 export const useBudgetStore = create((set, get) => ({
   sectors: initialSectors,
+  lang: 'en',
+  setLang: (lang) => set({ lang }),
 
   // Quest definitions
   quests: [

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,24 @@
+export const translations = {
+  en: {
+    increasing: 'Increasing',
+    decreasing: 'Decreasing',
+    will: 'will',
+    increase: 'increase',
+    decrease: 'reduce',
+    by: 'by',
+    impactInsights: 'Impact Insights'
+  },
+  ur: {
+    increasing: 'اضافہ',
+    decreasing: 'کمی',
+    will: 'سے',
+    increase: 'بڑھائے گا',
+    decrease: 'کم کرے گا',
+    by: 'سے',
+    impactInsights: 'اثرات'
+  }
+};
+
+export function t(key, lang = 'en') {
+  return translations[lang]?.[key] ?? translations.en[key] ?? key;
+}


### PR DESCRIPTION
## Summary
- show dynamic consequence messages with icons and fade-in
- add language support with simple i18n helper
- extend impact rules with health sector

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68964ce0b7dc832c9153383012c06bab