### PR TITLE
Fix quest score updates and quest card class

### DIFF
--- a/src/components/QuestPanel.jsx
+++ b/src/components/QuestPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, memo } from 'react';
+import { useCallback, memo } from 'react';
 import { useBudgetStore } from '../hooks/useBudgetStore';
 import { shallow } from 'zustand/shallow';
 
@@ -6,10 +6,9 @@ const QuestCard = memo(function QuestCard({ quest, active, onSelect }) {
   return (
     <button
       onClick={() => onSelect(quest.id)}
-      className={`p-3 rounded-md text-left w-60 transition transform hover:scale-105 focus:outline-none $
-        {
-          active ? 'bg-orange-500 text-white' : 'bg-blue-600 text-white'
-        }`}
+      className={`p-3 rounded-md text-left w-60 transition transform hover:scale-105 focus:outline-none ${
+        active ? 'bg-orange-500 text-white' : 'bg-blue-600 text-white'
+      }`}
     >
       <div className="font-semibold">{quest.name}</div>
       <p className="text-sm mt-1">{quest.description}</p>

--- a/src/components/ScoreBar.jsx
+++ b/src/components/ScoreBar.jsx
@@ -1,10 +1,14 @@
-import React, { memo } from 'react';
+import { memo } from 'react';
 import { useBudgetStore } from '../hooks/useBudgetStore';
 import { shallow } from 'zustand/shallow';
 
 const ScoreBar = () => {
+  // Selecting the score and success fields directly keeps the snapshot
+  // from changing on every render. Using the getter function previously
+  // returned a fresh object each time which triggered React's
+  // `useSyncExternalStore` warning and an update loop.
   const { score, success } = useBudgetStore(
-    (s) => s.getQuestScore(),
+    (s) => ({ score: s.score, success: s.success }),
     shallow
   );
   const barColor = success ? 'bg-green-500' : 'bg-red-500';


### PR DESCRIPTION
## Summary
- Ensure quest score bar uses stable snapshot to avoid `getSnapshot` infinite loop warning
- Use `active` quest flag in QuestCard className so ESLint passes and active quest highlights correctly
- Remove unused default React imports

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689672260344832c9d8c2ab9ffa43351