### PR TITLE
Fix React infinite loop by stabilizing store selectors

### DIFF
--- a/src/components/ImpactTooltip.jsx
+++ b/src/components/ImpactTooltip.jsx
@@ -4,11 +4,9 @@ import { useBudgetStore } from '../hooks/useBudgetStore';
 import { t } from '../i18n';
 
 export default function ImpactTooltip() {
-  // Pull state
-  const { sectors, lang } = useBudgetStore((state) => ({
-    sectors: state.sectors,
-    lang: state.lang || 'en',
-  }));
+  // Pull state; select each field individually so the snapshot is stable.
+  const sectors = useBudgetStore((state) => state.sectors);
+  const lang = useBudgetStore((state) => state.lang || 'en');
 
   // Build consequence messages
   const messages = sectors.flatMap((sec) => {

--- a/src/components/QuestPanel.jsx
+++ b/src/components/QuestPanel.jsx
@@ -1,6 +1,5 @@
 import { useCallback, memo } from 'react';
 import { useBudgetStore } from '../hooks/useBudgetStore';
-import { shallow } from 'zustand/shallow';
 
 const QuestCard = memo(function QuestCard({ quest, active, onSelect }) {
   return (
@@ -17,16 +16,13 @@ const QuestCard = memo(function QuestCard({ quest, active, onSelect }) {
 });
 
 function QuestPanel() {
-  const { quests, activeQuestId, setQuest, computeQuestScore } =
-    useBudgetStore(
-      (s) => ({
-        quests: s.quests,
-        activeQuestId: s.activeQuestId,
-        setQuest: s.setQuest,
-        computeQuestScore: s.computeQuestScore,
-      }),
-      shallow
-    );
+  // Select each piece of state individually to avoid returning a new object
+  // from the store selector. Returning new objects causes React 19 to warn
+  // about uncached snapshots and can lead to infinite re-render loops.
+  const quests = useBudgetStore((s) => s.quests);
+  const activeQuestId = useBudgetStore((s) => s.activeQuestId);
+  const setQuest = useBudgetStore((s) => s.setQuest);
+  const computeQuestScore = useBudgetStore((s) => s.computeQuestScore);
 
   const handleSelect = useCallback(
     (id) => {

--- a/src/components/ScoreBar.jsx
+++ b/src/components/ScoreBar.jsx
@@ -1,16 +1,12 @@
 import { memo } from 'react';
 import { useBudgetStore } from '../hooks/useBudgetStore';
-import { shallow } from 'zustand/shallow';
 
 const ScoreBar = () => {
-  // Selecting the score and success fields directly keeps the snapshot
-  // from changing on every render. Using the getter function previously
-  // returned a fresh object each time which triggered React's
-  // `useSyncExternalStore` warning and an update loop.
-  const { score, success } = useBudgetStore(
-    (s) => ({ score: s.score, success: s.success }),
-    shallow
-  );
+  // Select each field separately so the selector never returns a new object.
+  // React 19 requires snapshots from external stores to be referentially
+  // stable during a render; returning objects can trigger warnings and rerender loops.
+  const score = useBudgetStore((s) => s.score);
+  const success = useBudgetStore((s) => s.success);
   const barColor = success ? 'bg-green-500' : 'bg-red-500';
 
   return (

--- a/src/components/ToastContainer.jsx
+++ b/src/components/ToastContainer.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, memo } from 'react';
 import { useBudgetStore } from '../hooks/useBudgetStore';
-import { shallow } from 'zustand/shallow';
 
 const Toast = memo(function Toast({ id, message, onRemove }) {
   useEffect(() => {
@@ -16,10 +15,9 @@ const Toast = memo(function Toast({ id, message, onRemove }) {
 });
 
 export default function ToastContainer() {
-  const { toasts, removeToast } = useBudgetStore(
-    (s) => ({ toasts: s.toasts, removeToast: s.removeToast }),
-    shallow
-  );
+  // Select store slices individually to keep the snapshot stable.
+  const toasts = useBudgetStore((s) => s.toasts);
+  const removeToast = useBudgetStore((s) => s.removeToast);
 
   return (
     <div className="fixed top-4 right-4 space-y-2 z-50">


### PR DESCRIPTION
## Summary
- Avoid returning new objects from zustand selectors to prevent React 19 snapshot errors
- Stabilize QuestPanel, ScoreBar, ImpactTooltip and ToastContainer selectors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68967764f684832ca01788a48cf64a44