### PR TITLE
chore: ignore vendor build assets in lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,10 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  // Ignore built or vendored assets that aren't meant to be linted.
+  // This prevents third‑party bundles like the Soft UI Dashboard theme
+  // from triggering lint errors for undefined globals or duplicate keys.
+  globalIgnores(['dist', '**/build/**', 'soft-ui-dashboard-tailwind/**']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [


### PR DESCRIPTION
## Summary
- ignore build and Soft UI Dashboard assets in ESLint config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689767c01b2c832c8358e4c0c71f7f7d